### PR TITLE
License: Switch from GPL-3.0->GPL-3.0-only

### DIFF
--- a/foreman_openbolt.gemspec
+++ b/foreman_openbolt.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name        = 'foreman_openbolt'
   s.version     = ForemanOpenbolt::VERSION
   s.metadata    = { 'is_foreman_plugin' => 'true' }
-  s.license     = 'GPL-3.0'
+  s.license     = 'GPL-3.0-only'
   s.authors     = ['Overlook InfraTech']
   s.email       = ['contact@overlookinfratech.com']
   s.homepage    = 'https://github.com/overlookinfra/foreman_openbolt'


### PR DESCRIPTION
GPL-3.0 isn't a valid SPDX license identifier. Let's stick to GPL-3.0-only. We can always change it in the future if we want to allow other GPL versions as well.