### PR TITLE
Gemfile: remove duplicate theforeman-rubocop entry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'theforeman-rubocop', '~> 0.1.0'
-
 group :release, optional: true do
   gem 'faraday-retry', '~> 2.1', require: false
   gem 'github_changelog_generator', '~> 1.16.4', require: false


### PR DESCRIPTION
This is already declared in the gemspec.