### PR TITLE
@theforeman/builder: Allow newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@theforeman/builder": "^6.0.0",
+    "@theforeman/builder": ">= 6.0.0",
     "@theforeman/eslint-plugin-foreman": "6.0.0",
     "@theforeman/find-foreman": "^4.8.0",
     "@theforeman/test": "^8.0.0",


### PR DESCRIPTION
We made the same change to the rpm package we published:

https://github.com/theforeman/foreman-packaging/pull/12705/files#diff-b5ec701b3e5e372a9553366057d934109c7046f99ccea94e29127869b08851caR30

Marking as bugfix because 6.0.0 isn't packaged by foreman anymore.