### PR TITLE
Fix settings lookup and encrypted defaults in TaskController

### DIFF
--- a/app/controllers/foreman_openbolt/task_controller.rb
+++ b/app/controllers/foreman_openbolt/task_controller.rb
@@ -44,11 +44,18 @@ module ForemanOpenbolt
     def fetch_openbolt_options
       options = @openbolt_api.openbolt_options
 
-      # Get defaults from Foreman settings
+      # Get defaults from Foreman settings.
+      # For encrypted settings, show the placeholder only if a non-empty value
+      # has been saved, so the UI shows an empty field for unconfigured passwords
+      # instead of a misleading placeholder.
       defaults = {}
       openbolt_settings.each do |setting|
         key = setting.name.sub(/^openbolt_/, '')
-        defaults[key] = setting.encrypted? ? ENCRYPTED_PLACEHOLDER : setting.value unless setting.value.nil?
+        if setting.encrypted?
+          defaults[key] = ENCRYPTED_PLACEHOLDER unless setting.value.to_s.empty?
+        else
+          defaults[key] = setting.value
+        end
       end
 
       # Merge the defaults into the options metadata
@@ -230,7 +237,7 @@ module ForemanOpenbolt
     end
 
     def openbolt_settings
-      @openbolt_settings ||= Setting.where("name LIKE 'openbolt_%'")
+      @openbolt_settings ||= Foreman.settings.select { |s| s.name.start_with?('openbolt_') }
     end
 
     def encrypted_settings
@@ -238,13 +245,18 @@ module ForemanOpenbolt
     end
 
     def merge_encrypted_defaults(options)
-      encrypted = options.select { |_, v| v == ENCRYPTED_PLACEHOLDER }
-      encrypted.each do |key, _|
-        setting = Setting.find_by(name: "openbolt_#{key}")
-        raise ArgumentError, "No Foreman setting found for option '#{key}'. Configure it in Administer > Settings or provide a value." if setting.nil?
-        options[key] = setting.value
+      merged = options.dup
+      merged.each do |key, value|
+        next unless value == ENCRYPTED_PLACEHOLDER
+
+        saved = Setting["openbolt_#{key}"]
+        if saved.nil? || saved.to_s.empty?
+          raise ArgumentError,
+            "No saved value for encrypted option '#{key}'. Configure it in Administer > Settings or provide a value."
+        end
+        merged[key] = saved
       end
-      options
+      merged
     end
 
     def scrub_options_for_storage(options)

--- a/foreman_openbolt.spec.erb
+++ b/foreman_openbolt.spec.erb
@@ -6,7 +6,7 @@ LICENSES = JSON.load(File.read(File.join(root, 'licenses.json')))
 -%>
 %global gem_name <%= spec.name %>
 %global plugin_name <%= spec.name.sub(/\Aforeman_/, '') %>
-%global foreman_min_version 3.15.0
+%global foreman_min_version 3.17.0
 <%
 has_assets = spec.files.any? { |f| f.start_with?('app/assets/') }
 has_cronjob = spec.files.any? { |f| f =~ %r{\Aextra/.*\.cron\z} }
@@ -43,7 +43,7 @@ Source0: <%= download_path %>%{gem_name}-%{version}.gem
 
 # start specfile generated dependencies
 Requires: foreman >= %{foreman_min_version}
-Requires: rubygem(foreman-tasks) >= 8.3.0
+Requires: rubygem(foreman-tasks) >= 11.0.0
 <% if has_assets || has_webpack -%>
 BuildRequires: foreman-assets >= %{foreman_min_version}
 <% end -%>

--- a/test/unit/controllers/task_controller_test.rb
+++ b/test/unit/controllers/task_controller_test.rb
@@ -261,7 +261,7 @@ class TaskControllerTest < ActionController::TestCase
       }, session: @session
 
       assert_response :bad_request
-      assert_match(/No Foreman setting found/, JSON.parse(response.body)['error'])
+      assert_match(/No saved value for encrypted option/, JSON.parse(response.body)['error'])
     end
 
     test 'passes non-encrypted options through unchanged' do
@@ -298,7 +298,7 @@ class TaskControllerTest < ActionController::TestCase
       body = JSON.parse(response.body)
       assert_equal 'winrm', body['transport']['default']
       assert_equal 'admin', body['user']['default']
-      assert_nil body['verbose']['default']
+      assert_equal false, body['verbose']['default']
     end
 
     test 'shows encrypted placeholder instead of real value for encrypted settings' do


### PR DESCRIPTION
Use Foreman.settings registry instead of raw SQL queries. Show encrypted placeholder only when a real value has been saved, and return a new hash from merge_encrypted_defaults instead of mutating the caller's options. Also bump foreman_min_version and foreman-tasks requirement in the spec.