### PR TITLE
Add prepare_release and update release automation

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,83 @@
+---
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.2.0)'
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  BUNDLE_WITH: release
+
+jobs:
+  prepare_release:
+    name: Prepare Release
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'overlookinfra'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version '$VERSION' must be in X.Y.Z format"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'ruby'
+          bundler-cache: true
+
+      - name: Bump version in version.rb
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/VERSION = '.*'/VERSION = '$VERSION'/" lib/foreman_openbolt/version.rb
+          grep -q "VERSION = '$VERSION'" lib/foreman_openbolt/version.rb || {
+            echo "::error::Failed to update version in version.rb"
+            exit 1
+          }
+
+      - name: Bump version in package.json
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
+          grep -q "\"version\": \"$VERSION\"" package.json || {
+            echo "::error::Failed to update version in package.json"
+            exit 1
+          }
+
+      - name: Generate changelog
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ github.token }}
+        run: bundle exec rake changelog
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "Release ${{ inputs.version }}"
+          branch: "release-${{ inputs.version }}"
+          delete-branch: true
+          title: "Release ${{ inputs.version }}"
+          labels: skip-changelog
+          assignees: '${{ github.triggering_actor }}'
+          body: |
+            Automated release prep for version ${{ inputs.version }}.
+
+            After merging this PR, run the **Release** workflow to create the tag and publish the gem.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,78 @@
 ---
-name: Gem Release
+name: Release
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.2.0)'
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
-  build-release:
+  create-tag:
+    name: Create tag
+    runs-on: ubuntu-24.04
     # Prevent releases from forked repositories
     if: github.repository_owner == 'overlookinfra'
+    permissions:
+      contents: write
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version '$VERSION' must be in X.Y.Z format"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify source version matches release version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! grep -q "VERSION = '$VERSION'" lib/foreman_openbolt/version.rb; then
+            echo "::error::version.rb does not contain version '$VERSION'. Did you merge the prepare-release PR?"
+            exit 1
+          fi
+          if ! grep -q "\"version\": \"$VERSION\"" package.json; then
+            echo "::error::package.json does not contain version '$VERSION'. Did you merge the prepare-release PR?"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$(git tag -l "$VERSION")" ]; then
+            echo "::error::Tag '$VERSION' already exists"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+  build-release:
+    needs: create-tag
     name: Build the gem
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -46,7 +103,8 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create --repo ${{ github.repository }} ${{ github.ref_name }} --generate-notes *.gem
+          VERSION: ${{ inputs.version }}
+        run: gh release create --repo ${{ github.repository }} "$VERSION" --generate-notes *.gem
 
   release-to-github:
     needs: build-release

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,5 @@ end
 
 group :release, optional: true do
   gem 'faraday-retry', '~> 2.1', require: false
-  gem 'github_changelog_generator', '~> 1.16.4', require: false
+  gem 'github_changelog_generator', '~> 1.18', require: false
 end

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ### Version locations
 
-Update the version in these files:
+The version is maintained in two files:
 
 1. `lib/foreman_openbolt/version.rb` -- the gem version (authoritative source)
 2. `package.json` -- the npm package version (must match)
@@ -264,18 +264,13 @@ If the minimum Foreman version changes, also update:
 
 ### Release steps
 
-1. Bump the version in the two files listed above
-2. Generate the changelog:
-   ```bash
-   CHANGELOG_GITHUB_TOKEN=github_pat_... bundle exec rake changelog
-   ```
-3. Create a PR with the version bump and changelog, get it reviewed and merged
-4. Create and push a tag matching the version:
-   ```bash
-   git tag 1.1.0
-   git push origin 1.1.0
-   ```
-5. The [release workflow](.github/workflows/release.yml) runs automatically on tag push and:
+1. Go to [Actions > Prepare Release](../../actions/workflows/prepare_release.yml) and run the workflow with the version to release (e.g. `1.2.0`)
+2. The workflow bumps the version in `version.rb` and `package.json`, generates the changelog, and opens a PR with the `skip-changelog` label
+3. Review and merge the PR
+4. Go to [Actions > Release](../../actions/workflows/release.yml) and run the workflow with the same version
+5. The release workflow:
+   - Verifies the version in `version.rb` matches the input
+   - Creates and pushes a git tag
    - Builds the gem
    - Creates a GitHub Release with auto-generated notes and the gem attached
    - Publishes the gem to GitHub Packages


### PR DESCRIPTION
This takes care of the version bumps, changelog, tagging, and releasing so we don't have to do manual steps.