### PR TITLE
Add Choria transport support and a few fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ A task is copied to N targets and executed there.
 
 ## Plans
 
-Plans provide complex logic options, written in Puppet DSL.
-Besides the usual Puppet DSL functions, it's also possible to execute tasks and evaluate their responses.
+Plans provide complex logic options, written in the Puppet language.
+Besides the usual Puppet language functions, it's also possible to execute tasks and evaluate their responses.
 
 ## OpenBolt in Foreman!
 
-OpenBolt is the Ansible counterpart and OpenBolt is Puppet "native".
-OpenBolt and Puppet integrate very well together and OpenBolt can reuse your existing Puppet code.
-Since OpenBolt is a CLI only application, and most Puppet users run Foreman anyways, it made sense to integrate OpenBolt into Foreman, instead of writing another web UI.
+OpenBolt is the Ansible counterpart and OpenBolt is OpenVox/Puppet native.
+OpenBolt and OpenVox/Puppet integrate very well together and OpenBolt can reuse your existing code.
+Since OpenBolt is a CLI only application, and most OpenVox and Puppet users run Foreman anyways, it made sense to integrate OpenBolt into Foreman, instead of writing another web UI.
 
 ## Installation
 
@@ -49,7 +49,9 @@ The [theforeman/foreman_proxy](https://github.com/theforeman/puppet-foreman_prox
 The Foreman plugin provides UI elements to start Tasks on various nodes.
 Foreman then talks to a Smartproxy to run OpenBolt.
 The Smartproxy also establishes the connections to the various targets.
-This is usually a ssh or WinRM connection (and soon choria, see [the TODO section](#todo)).
+This is usually a SSH, WinRM, or Choria connection. The Choria transport
+requires OpenBolt 5.5 or later and is not available in Puppet Bolt.
+SSH and WinRM transports work with any version.
 
 You need to have `bolt` in your `$PATH` on the Smartproxy.
 OpenBolt packages are available at [yum.voxpupuli.org](https://yum.voxpupuli.org/) & [apt.voxpupuli.org](https://apt.voxpupuli.org/) in the openvox8 repo.
@@ -57,172 +59,18 @@ You can also use the legacy Bolt packages from Perforce from the `puppet-tools` 
 
 The integration is supported on Foreman 3.17 and all following versions, including development/nightly builds.
 
-OpenBolt relies on Tasks & Plans. They are distributed as puppet modules.
+OpenBolt relies on Tasks & Plans. They are distributed as modules.
 The plugin assumes that you deployed your code.
 We recommend to use [r10k](https://github.com/puppetlabs/r10k?tab=readme-ov-file#r10k) or [g10k](https://github.com/xorpaul/g10k?tab=readme-ov-file#g10k) to deploy code, as you do it on your compilers.
 
 A handful of core/default Tasks & Plans are also included in the [OpenBolt rpm/deb packages](https://github.com/OpenVoxProject/openbolt/blob/main/Puppetfile).
 
-## Usage
+## Documentation
 
-(all screenshots were taken on Foreman 3.17)
-
-After installation, you will see a new UI element
-
-![foreman UI menu screenshot](./ext/foreman-ui-menu.png)
-
-The "Launch Task" option allows you to select any smartproxy with the `openbolt` feature (which is available when the OpenBolt Smartproxy plugin is installed).
-Afterwards you can select N targets to run the task and select an available task from the selected Smartproxy.
-On the right side you can configure OpenBolt connection settings.
-
-![launch task detail view](./ext/foreman-launch-task.png)
-
-After selecting a task, the task metadata is fetched and shown.
-Additional input elements will appear, if the task support it.
-
-![service task metadata](./ext/task-metadata-minimal.png)
-
-The metadata can contains a description and datatypes for tasks.
-Those information can be shown as well.
-
-![service task detailed metadata](./ext/task-metadata.png)
-
-While the task is running, the UI polls the status from the smart proxy.
-
-![task loading screen](./ext/task-running.png)
-
-After the task finished, it will display a success for failure page.
-
-![failed task view](./ext/task-execution-details.png)
-
-You can also see the used parameters for a task.
-
-![task used parameters](./ext/task-task-details.png)
-
-We also display the used OpenBolt command line, in case you want to manually run it or debug it.
-
-![display used OpenBolt command](./ext/task-log-output.png)
-
-OpenBolt returns JSON for executed tasks.
-That's visible in the UI.
-For failed tasks but also for passed tasks.
-
-![failed task output](./ext/task-result.png)
-
-![service task passed on two nodes](./ext/task-successful-result.png)
-
-## Development
-
-### Linting
-
-```bash
-bundle exec rake lint        # Run all linters (rubocop, erb_lint, eslint)
-bundle exec rake lint:fix    # Auto-fix where possible
-```
-
-Ruby and ERB linters run directly. The JavaScript linter requires npm dependencies, so either install them locally (`npm install --legacy-peer-deps`) or run lint:js inside a container:
-
-```bash
-CONTAINER=1 bundle exec rake lint:js
-```
-
-### Unit Tests
-
-Unit tests run inside Docker containers with a full Foreman installation. Requires Docker with compose support.
-
-```bash
-bundle exec rake test:unit:up    # Build image, start containers, install deps
-bundle exec rake test:unit:ruby  # Run Ruby tests
-bundle exec rake test:unit:js    # Run JavaScript tests
-bundle exec rake test:unit:all   # Run all unit tests
-bundle exec rake test:unit:down  # Stop and remove containers
-bundle exec rake test              # Shortcut: up, test, down in one step
-```
-
-Set `FOREMAN_VERSION` to test against a specific Foreman version (default: `3.18`):
-
-```bash
-FOREMAN_VERSION=3.17 bundle exec rake test:unit:up
-```
-
-### Acceptance Tests
-
-Acceptance tests exercise the plugin through the browser using Capybara and Selenium. They build RPMs, start a multi-container environment (Foreman + OpenVox + SSH targets + Chromium), and run tests against the real UI.
-
-**Prerequisites:**
-
-```bash
-bundle install --with acceptance
-```
-
-The [smart_proxy_openbolt](https://github.com/overlookinfra/smart_proxy_openbolt) and [foreman-packaging](https://github.com/theforeman/foreman-packaging) repos are cloned automatically when needed.
-
-**Running:**
-
-```bash
-bundle exec rake acceptance         # Full cycle: up, run tests, down
-bundle exec rake acceptance:up      # Build RPMs, start Foreman, configure everything
-bundle exec rake acceptance:run     # Run tests (requires up first)
-bundle exec rake acceptance:down    # Stop containers
-bundle exec rake acceptance:clean   # Full reset: stop containers, remove images and artifacts
-```
-
-The `acceptance:up` task is idempotent and can be re-run to pick up new RPM changes. It caches the Foreman Docker image per version so subsequent runs are faster.
-
-**Watching tests in the browser:**
-
-Set `HEADFUL=1` to disable headless mode, then open `http://localhost:7900` (password: `secret`) to watch the tests via noVNC:
-
-```bash
-HEADFUL=1 bundle exec rake acceptance:run
-```
-
-**Running a subset of tests:**
-
-`acceptance:run` accepts `TEST=<path>` to limit which test files are loaded, and `TESTOPTS=<opts>` to forward options (e.g. `--name=/pattern/`) to the Test::Unit autorunner. Both can be combined.
-
-```bash
-# Run every test in one file
-bundle exec rake acceptance:run TEST=test/acceptance/tests/settings_test.rb
-
-# Run a single test by exact method name (any file)
-bundle exec rake acceptance:run TESTOPTS='--name=test_echo_task_succeeds_on_all_targets'
-
-# Run tests whose name matches a regex within one file
-bundle exec rake acceptance:run \
-  TEST=test/acceptance/tests/settings_test.rb \
-  TESTOPTS='--name=/host_key/'
-```
-
-**Environment variables:**
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CHROMEDRIVER_URL` | `http://localhost:4444` | Selenium WebDriver endpoint |
-| `FOREMAN_BRANCH` | `<version>-stable` | Foreman git branch for unit test image (derived from `FOREMAN_VERSION`) |
-| `FOREMAN_PACKAGING_REPO` | `https://github.com/theforeman/foreman-packaging.git` | Git URL for foreman-packaging (cloned automatically for RPM builds) |
-| `FOREMAN_PASS` | `changeme` | Foreman login password |
-| `FOREMAN_URL` | `https://foreman` | Foreman URL as seen by Chrome. Override to run tests against a live instance |
-| `FOREMAN_USER` | `admin` | Foreman login username |
-| `FOREMAN_VERSION` | `3.18` | Foreman version to test against |
-| `HEADFUL` | unset | Set to `1` to show the browser in noVNC |
-| `SELENIUM_IMAGE` | auto-detected (ARM/x86) | Selenium container image (auto-selects `seleniarm/standalone-chromium` or `selenium/standalone-chrome`) |
-| `SMART_PROXY_OPENBOLT_REF` | `main` | Branch or tag to clone |
-| `SMART_PROXY_OPENBOLT_REPO` | `https://github.com/overlookinfra/smart_proxy_openbolt.git` | Git URL for smart_proxy_openbolt (cloned automatically for RPM builds) |
-
-### Building Packages
-
-Build RPM or DEB packages locally using containers. The [foreman-packaging](https://github.com/theforeman/foreman-packaging) repo is cloned automatically:
-
-```bash
-bundle exec rake build:rpm   # Build RPM
-bundle exec rake build:deb   # Build DEB
-```
-
-## TODO
-
-* Integrate plans into the web UI
-* Provide a choria transport plugin
+- [Usage](docs/usage.md): screenshots and walkthrough of the UI
+- [Development](docs/development.md): linting, unit tests, acceptance tests, building packages
+- [Releasing](docs/releasing.md): version locations, release steps, RPM/DEB packaging
+- [Choria Testing](docs/choria-testing.md): setting up Choria on a Foreman install for transport testing
 
 ## Contributing & support
 
@@ -247,83 +95,3 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-## How to Release
-
-### Version locations
-
-The version is maintained in two files:
-
-1. `lib/foreman_openbolt/version.rb` -- the gem version (authoritative source)
-2. `package.json` -- the npm package version (must match)
-
-If the minimum Foreman version changes, also update:
-
-3. `lib/foreman_openbolt/engine.rb` -- `requires_foreman '>= X.Y.Z'`
-4. `.github/workflows/build.yml` -- default `foreman_version` and `foreman_packaging_ref` inputs
-
-### Release steps
-
-1. Go to [Actions > Prepare Release](../../actions/workflows/prepare_release.yml) and run the workflow with the version to release (e.g. `1.2.0`)
-2. The workflow bumps the version in `version.rb` and `package.json`, generates the changelog, and opens a PR with the `skip-changelog` label
-3. Review and merge the PR
-4. Go to [Actions > Release](../../actions/workflows/release.yml) and run the workflow with the same version
-5. The release workflow:
-   - Verifies the version in `version.rb` matches the input
-   - Creates and pushes a git tag
-   - Builds the gem
-   - Creates a GitHub Release with auto-generated notes and the gem attached
-   - Publishes the gem to GitHub Packages
-   - Publishes the gem to RubyGems.org (requires the `release` environment)
-   - Verifies the gem is available on RubyGems.org
-
-### RPM/DEB packaging
-
-After the gem is published to RubyGems, both RPM and DEB packages need to be updated in [theforeman/foreman-packaging](https://github.com/theforeman/foreman-packaging).
-
-A bot automatically creates PRs against the `rpm/develop` and `deb/develop` branches to pick up the new gem version. These PRs build packages for Foreman nightly.
-
-For stable Foreman releases (currently 3.17 and 3.18), cherry-pick the packaging commits from the develop branches into the corresponding stable branches. For each stable version you want to support:
-
-```bash
-cd foreman-packaging
-
-# RPM: cherry-pick from rpm/develop into a branch off the stable target
-git checkout rpm/3.18
-git checkout -b cherry-pick/rubygem-foreman_openbolt-rpm-3.18
-git cherry-pick <commit-from-rpm/develop>
-# Push to your fork and open a PR targeting rpm/3.18
-
-# DEB: same approach for the deb side
-git checkout deb/3.18
-git checkout -b cherry-pick/rubygem-foreman-openbolt-deb-3.18
-git cherry-pick <commit-from-deb/develop>
-# Push to your fork and open a PR targeting deb/3.18
-```
-
-PRs against stable branches should be labeled "Stable branch".
-
-**Alternative: manual version bump**
-
-If the cherry-pick doesn't apply cleanly, you can bump the version manually on the stable branch instead.
-
-*RPM:* Checkout the target branch and run `bump_rpm.sh`:
-```bash
-cd foreman-packaging
-git checkout rpm/3.18
-git checkout -b bump_rpm/rubygem-foreman_openbolt
-./bump_rpm.sh packages/plugins/rubygem-foreman_openbolt
-# Review changes, push to your fork, and open a PR targeting rpm/3.18
-```
-
-*DEB:* Checkout the target branch and update these files:
-- `debian/gem.list` -- new gem filename
-- `foreman_openbolt.rb` -- new version
-- `debian/control` -- dependency versions (if changed)
-- `debian/changelog` -- add a new entry
-
-```bash
-git checkout deb/3.18
-git checkout -b bump_deb/ruby-foreman-openbolt
-# Make the changes above, push to your fork, and open a PR targeting deb/3.18
-```

--- a/app/controllers/foreman_openbolt/task_controller.rb
+++ b/app/controllers/foreman_openbolt/task_controller.rb
@@ -53,7 +53,7 @@ module ForemanOpenbolt
         key = setting.name.sub(/^openbolt_/, '')
         if setting.encrypted?
           defaults[key] = ENCRYPTED_PLACEHOLDER unless setting.value.to_s.empty?
-        else
+        elsif !setting.value.to_s.empty?
           defaults[key] = setting.value
         end
       end
@@ -136,6 +136,9 @@ module ForemanOpenbolt
       rescue ActiveRecord::RecordInvalid => e
         log_exception('launch_task', e)
         render_error("Database error: #{e.message}", :internal_server_error)
+      rescue ProxyAPI::ProxyException => e
+        log_exception('launch_task', e)
+        render_error("Smart Proxy error: #{e.message}", :bad_gateway)
       rescue StandardError => e
         log_exception('launch_task', e)
         render_error("Error launching task: #{e.message}", :internal_server_error)

--- a/docs/choria-testing.md
+++ b/docs/choria-testing.md
@@ -1,0 +1,314 @@
+# Setting Up Choria for OpenBolt Testing
+
+This guide covers installing and configuring Choria on a Foreman-managed
+infrastructure so you can test the Choria transport with OpenBolt. It
+assumes Foreman is already running with an OpenVox Server (or Puppet
+Server) and CA, and that your managed nodes have signed OpenVox/Puppet
+agent certificates.
+
+Choria uses your existing OpenVox/Puppet CA for all TLS. No separate PKI
+is needed.
+
+## Architecture
+
+| Role | Host | What gets installed |
+|---|---|---|
+| Broker + Client | Foreman primary (Foreman, OpenVox/Puppet Server, smart proxy, OpenBolt) | `choria` package (Go binary, embedded NATS on port 4222), `choria` CLI, `choria-mcorpc-support` gem (bundled in OpenBolt) |
+| Server | Each managed node | `choria` package (includes `bolt_tasks` agent) + `shell` agent (optional) |
+
+## Prerequisites
+
+- **OpenBolt 5.5 or later** (the Choria transport is not available in Puppet Bolt)
+- Foreman with a working OpenVox Server (or Puppet Server) and CA
+- Managed nodes with signed OpenVox/Puppet agent certificates
+- Certnames that match FQDNs (the default for both OpenVox/Puppet and Choria)
+- Port 4222 open from all nodes to the Foreman primary
+- Port 8140 open from all nodes to the OpenVox/Puppet Server (task file downloads)
+
+## Step 1: Install modules
+
+### With a Puppetfile (r10k / Code Manager)
+
+r10k does not resolve transitive dependencies automatically, so all
+modules must be listed explicitly. Add to your Puppetfile:
+
+```ruby
+# Choria core
+mod 'choria/choria',                        :latest
+mod 'choria/mcollective',                   :latest
+mod 'choria/mcollective_choria',            :latest
+
+# Choria standard agents (dependencies of choria/choria)
+mod 'choria/mcollective_agent_filemgr',     :latest
+mod 'choria/mcollective_agent_package',     :latest
+mod 'choria/mcollective_agent_puppet',      :latest
+mod 'choria/mcollective_agent_service',     :latest
+mod 'choria/mcollective_util_actionpolicy', :latest
+
+# Task agent configuration (agent code ships with choria, module provides the Puppet class)
+mod 'choria/mcollective_agent_bolt_tasks',  :latest
+
+# Shell agent for alternative task execution (>= 1.2.1, GitHub only)
+mod 'mcollective_agent_shell',
+  git: 'https://github.com/choria-plugins/shell-agent',
+  ref: '1.2.1'
+
+# Dependencies (skip any already in your environment)
+mod 'puppetlabs/stdlib',   :latest
+mod 'puppetlabs/apt',      :latest
+mod 'puppetlabs/concat',   :latest
+mod 'puppetlabs/inifile',  :latest
+mod 'puppet/systemd',      :latest
+```
+
+The `bolt_tasks` agent code ships with the `choria` package, but the
+`choria/mcollective_agent_bolt_tasks` Puppet module is still needed to
+provide the class that `mcollective::plugin_classes` includes for
+configuration.
+
+You also need any task modules you want to run in the environment. The
+`bolt_tasks` agent downloads task files from the OpenVox/Puppet Server
+at runtime. For example, to use the `facts` task:
+
+```ruby
+mod 'puppetlabs/facts',    :latest
+```
+
+Then deploy:
+
+```bash
+r10k deploy environment production
+```
+
+### Without a Puppetfile (puppet module install)
+
+`puppet module install` resolves Forge dependencies automatically. Modules
+install into `/etc/puppetlabs/code/environments/production/modules/` by
+default.
+
+```bash
+puppet module install choria-choria
+puppet module install choria-mcollective_agent_bolt_tasks
+```
+
+Install any task modules you want to run. The `bolt_tasks` agent
+downloads task files from the OpenVox/Puppet Server at runtime:
+
+```bash
+puppet module install puppetlabs-facts
+```
+
+For the shell agent (GitHub-only at the required version):
+
+```bash
+cd /etc/puppetlabs/code/environments/production/modules/
+git clone https://github.com/choria-plugins/shell-agent.git mcollective_agent_shell
+cd mcollective_agent_shell && git checkout 1.2.1
+```
+
+## Step 2: Verify server authorization rules
+
+The `bolt_tasks` agent downloads task files from the OpenVox/Puppet
+Server via the `/puppet/v3/file_content` and `/puppet/v3/tasks`
+endpoints. These are allowed for all authenticated nodes in the default
+`auth.conf`. If you have customized your server's
+`/etc/puppetlabs/puppetserver/conf.d/auth.conf`, verify that these
+endpoints are not blocked.
+
+## Step 3: Hiera data
+
+Add the following to your common Hiera data. The `choria` module defaults
+to `manage_package_repo: true` and `server: true`, so those do not need
+to be set explicitly. The `puppetserver_port` defaults to `8140`.
+
+`/etc/puppetlabs/code/environments/production/data/common.yaml`:
+
+```yaml
+choria::server_config:
+  plugin.choria.middleware_hosts: "primary.example.com:4222"
+  plugin.choria.puppetserver_host: "primary.example.com"
+  plugin.choria.use_srv: false
+
+mcollective::plugin_classes:
+  - mcollective_agent_bolt_tasks
+  - mcollective_agent_shell
+
+mcollective_choria::config:
+  security.certname_whitelist: "/.*/"
+
+mcollective::site_policies:
+  - action: "allow"
+    callers: "/.*/"
+    actions: "*"
+    facts: "*"
+    classes: "*"
+```
+
+Replace `primary.example.com` with your OpenVox/Puppet Server FQDN. If
+your server resolves as `puppet` (the default), you can omit
+`plugin.choria.puppetserver_host`.
+
+The `certname_whitelist` and `site_policies` above allow all callers for
+testing. In production, replace `/.*/` with a more restrictive pattern
+such as `/.*\.example\.com$/` to limit accepted certnames and callers.
+
+## Step 4: Site manifest
+
+Add Choria classes to your node definitions in
+`/etc/puppetlabs/code/environments/production/manifests/site.pp`:
+
+```puppet
+# Foreman primary: broker + server
+node 'primary.example.com' {
+  include choria
+  include choria::broker
+}
+
+# Managed nodes: server only
+node default {
+  include choria
+}
+```
+
+The `choria::broker` class enables the embedded NATS broker. It only
+needs to be included on the primary.
+
+## Step 5: Deploy
+
+On the **primary**, run Puppet first (sets up the broker):
+
+```bash
+puppet agent -t
+```
+
+Then on **each managed node**:
+
+```bash
+puppet agent -t
+```
+
+Verify `choria-server` is running on **each node** (including the
+primary):
+
+```bash
+systemctl status choria-server
+```
+
+## Step 6: Verify connectivity
+
+On the **primary**, verify that all nodes are reachable via Choria.
+The `choria ping` command works as root using the server config:
+
+```bash
+choria ping
+```
+
+All nodes (including the primary) should respond with their FQDNs.
+Confirm the `bolt_tasks` agent is loaded on the managed nodes:
+
+```bash
+choria rpc rpcutil agent_inventory -I node1.example.com
+```
+
+Look for `bolt_tasks` in the agents list.
+
+## Step 7: Test with OpenBolt directly
+
+On the **primary**, test the OpenBolt path as the `foreman-proxy` user.
+The `--choria-mcollective-certname` flag is needed because the
+`choria-mcorpc-support` library identifies non-root users as
+`<username>.mcollective`, which does not match the host's certificate CN.
+When running through the smart proxy, this is handled automatically.
+
+```bash
+cd /tmp && sudo -u foreman-proxy bolt task run facts \
+  --targets node1.example.com,node2.example.com \
+  --transport choria \
+  --choria-brokers primary.example.com:4222 \
+  --choria-ssl-cert /etc/puppetlabs/puppet/ssl/certs/$(puppet config print certname).pem \
+  --choria-ssl-key /etc/puppetlabs/puppet/ssl/private_keys/$(puppet config print certname).pem \
+  --choria-ssl-ca /etc/puppetlabs/puppet/ssl/certs/ca.pem \
+  --choria-mcollective-certname $(puppet config print certname)
+```
+
+Replace `primary.example.com` with your OpenVox/Puppet Server FQDN. The
+port defaults to 4222 if omitted. Do not use the `nats://` prefix. If
+`--choria-brokers` is omitted entirely, the Choria client checks the
+config file, then SRV records, then falls back to `puppet:4222`.
+
+## Step 8: Configure Foreman
+
+Once the `smart_proxy_openbolt` and `foreman_openbolt` Choria support is
+deployed, select "Choria" in the transport dropdown on the Launch Task
+page. The one setting you may need to evaluate is **Choria Brokers**
+(under Administer > Settings > OpenBolt). If `puppet` resolves to the
+broker host or SRV records are configured, it can be left blank.
+Otherwise, set it to your broker's address:
+
+| Setting | Example value |
+|---|---|
+| Choria Brokers | `primary.example.com:4222` |
+
+Other Choria settings (SSL, the default config file, certname) are
+derived automatically by the proxy and can be ignored unless your
+Choria configuration requires customization. The default config file
+used by the proxy is at `lib/smart_proxy_openbolt/config/choria-client.conf`
+in the `smart_proxy_openbolt` gem.
+
+### Advanced: custom Choria configuration file
+
+If you need full control over the MCollective client configuration, set
+the "Choria Config File" setting under Administer > Settings > OpenBolt to the path of your
+custom configuration file. When a custom config file is provided, the
+proxy does not inject SSL defaults (the config file is expected to
+handle SSL on its own). If you also set the Choria SSL settings in
+Foreman, those override the values in the config file.
+
+## Important notes
+
+- **Target names must match Choria identities.** Use the FQDNs shown by
+  `choria ping`. Mismatches cause silent timeouts.
+- **Task modules must exist on the OpenVox/Puppet Server** in the
+  production environment (or whichever environment you configure via the
+  Choria Puppet Environment setting). The `bolt_tasks` agent downloads
+  task files from the OpenVox/Puppet Server at runtime.
+- **Certnames must match FQDNs** by default in Choria.
+- **The broker listens on port 4222.** For clustered deployments, port
+  4223 handles inter-broker communication.
+
+## Troubleshooting
+
+**`choria ping` returns no results:**
+- Verify `choria-server` is running on the target nodes
+  (`systemctl status choria-server`).
+- Verify the broker is running on the primary
+  (`systemctl status choria-broker` or check port 4222).
+- Check that `plugin.choria.middleware_hosts` in the node config points
+  to the correct broker FQDN and port.
+- Verify the client certificate is signed by the same OpenVox/Puppet CA
+  (`openssl verify -CAfile ca.pem client.pem`).
+
+**`bolt task run` fails with "no nodes replied":**
+- Confirm the target names match the identities shown by `choria ping`
+  exactly.
+- Verify `bolt_tasks` appears in the agent list
+  (`choria rpc rpcutil agent_inventory -I <target>`).
+
+**Task downloads fail:**
+- Confirm the OpenVox/Puppet Server authorization rules from Step 2 are
+  not blocked (`puppetserver reload` after any auth.conf changes).
+- Verify the task module exists in the production environment
+  modulepath on the OpenVox/Puppet Server.
+
+**Agent not found after install:**
+- Restart `choria-server` on the target node. Choria only loads agents
+  at startup.
+
+## References
+
+- [Choria Deployment Requirements](https://choria.io/docs/deployment/requirements/)
+- [Choria Network Broker](https://choria.io/docs/deployment/broker/)
+- [Choria Server Configuration](https://choria.io/docs/configuration/choria_server/)
+- [Choria Security Model](https://choria.io/docs/concepts/security/)
+- [Choria First User Setup](https://choria.io/docs/deployment/first-user/)
+- [Choria Puppet Tasks Configuration](https://choria.io/docs/tasks/configuration/)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,107 @@
+# Development
+
+## Linting
+
+```bash
+bundle exec rake lint        # Run all linters (rubocop, erb_lint, eslint)
+bundle exec rake lint:fix    # Auto-fix where possible
+```
+
+Ruby and ERB linters run directly. The JavaScript linter requires npm dependencies, so either install them locally (`npm install --legacy-peer-deps`) or run lint:js inside a container:
+
+```bash
+CONTAINER=1 bundle exec rake lint:js
+```
+
+## Unit Tests
+
+Unit tests run inside Docker containers with a full Foreman installation. Requires Docker with compose support.
+
+```bash
+bundle exec rake test:unit:up    # Build image, start containers, install deps
+bundle exec rake test:unit:ruby  # Run Ruby tests
+bundle exec rake test:unit:js    # Run JavaScript tests
+bundle exec rake test:unit:all   # Run all unit tests
+bundle exec rake test:unit:down  # Stop and remove containers
+bundle exec rake test              # Shortcut: up, test, down in one step
+```
+
+Set `FOREMAN_VERSION` to test against a specific Foreman version (default: `3.18`):
+
+```bash
+FOREMAN_VERSION=3.17 bundle exec rake test:unit:up
+```
+
+## Acceptance Tests
+
+Acceptance tests exercise the plugin through the browser using Capybara and Selenium. They build RPMs, start a multi-container environment (Foreman + OpenVox + SSH targets + Chromium), and run tests against the real UI.
+
+**Prerequisites:**
+
+```bash
+bundle install --with acceptance
+```
+
+The [smart_proxy_openbolt](https://github.com/overlookinfra/smart_proxy_openbolt) and [foreman-packaging](https://github.com/theforeman/foreman-packaging) repos are cloned automatically when needed.
+
+**Running:**
+
+```bash
+bundle exec rake acceptance         # Full cycle: up, run tests, down
+bundle exec rake acceptance:up      # Build RPMs, start Foreman, configure everything
+bundle exec rake acceptance:run     # Run tests (requires up first)
+bundle exec rake acceptance:down    # Stop containers
+bundle exec rake acceptance:clean   # Full reset: stop containers, remove images and artifacts
+```
+
+The `acceptance:up` task is idempotent and can be re-run to pick up new RPM changes. It caches the Foreman Docker image per version so subsequent runs are faster.
+
+**Watching tests in the browser:**
+
+Set `HEADFUL=1` to disable headless mode, then open `http://localhost:7900` (password: `secret`) to watch the tests via noVNC:
+
+```bash
+HEADFUL=1 bundle exec rake acceptance:run
+```
+
+**Running a subset of tests:**
+
+`acceptance:run` accepts `TEST=<path>` to limit which test files are loaded, and `TESTOPTS=<opts>` to forward options (e.g. `--name=/pattern/`) to the Test::Unit autorunner. Both can be combined.
+
+```bash
+# Run every test in one file
+bundle exec rake acceptance:run TEST=test/acceptance/tests/settings_test.rb
+
+# Run a single test by exact method name (any file)
+bundle exec rake acceptance:run TESTOPTS='--name=test_echo_task_succeeds_on_all_targets'
+
+# Run tests whose name matches a regex within one file
+bundle exec rake acceptance:run \
+  TEST=test/acceptance/tests/settings_test.rb \
+  TESTOPTS='--name=/host_key/'
+```
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHROMEDRIVER_URL` | `http://localhost:4444` | Selenium WebDriver endpoint |
+| `FOREMAN_BRANCH` | `<version>-stable` | Foreman git branch for unit test image (derived from `FOREMAN_VERSION`) |
+| `FOREMAN_PACKAGING_REPO` | `https://github.com/theforeman/foreman-packaging.git` | Git URL for foreman-packaging (cloned automatically for RPM builds) |
+| `FOREMAN_PASS` | `changeme` | Foreman login password |
+| `FOREMAN_URL` | `https://foreman` | Foreman URL as seen by Chrome. Override to run tests against a live instance |
+| `FOREMAN_USER` | `admin` | Foreman login username |
+| `FOREMAN_VERSION` | `3.18` | Foreman version to test against |
+| `HEADFUL` | unset | Set to `1` to show the browser in noVNC |
+| `SELENIUM_IMAGE` | auto-detected (ARM/x86) | Selenium container image (auto-selects `seleniarm/standalone-chromium` or `selenium/standalone-chrome`) |
+| `SMART_PROXY_OPENBOLT_REF` | `main` | Branch or tag to clone |
+| `SMART_PROXY_OPENBOLT_REPO` | `https://github.com/overlookinfra/smart_proxy_openbolt.git` | Git URL for smart_proxy_openbolt (cloned automatically for RPM builds) |
+
+## Building Packages
+
+Build RPM or DEB packages locally using containers. The [foreman-packaging](https://github.com/theforeman/foreman-packaging) repo is cloned automatically:
+
+```bash
+bundle exec rake build:rpm   # Build RPM
+bundle exec rake build:deb   # Build DEB
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,79 @@
+# How to Release
+
+## Version locations
+
+The version is maintained in two files:
+
+1. `lib/foreman_openbolt/version.rb` -- the gem version (authoritative source)
+2. `package.json` -- the npm package version (must match)
+
+If the minimum Foreman version changes, also update:
+
+3. `lib/foreman_openbolt/engine.rb` -- `requires_foreman '>= X.Y.Z'`
+4. `.github/workflows/build.yml` -- default `foreman_version` and `foreman_packaging_ref` inputs
+
+## Release steps
+
+1. Go to [Actions > Prepare Release](../../actions/workflows/prepare_release.yml) and run the workflow with the version to release (e.g. `1.2.0`)
+2. The workflow bumps the version in `version.rb` and `package.json`, generates the changelog, and opens a PR with the `skip-changelog` label
+3. Review and merge the PR
+4. Go to [Actions > Release](../../actions/workflows/release.yml) and run the workflow with the same version
+5. The release workflow:
+   - Verifies the version in `version.rb` matches the input
+   - Creates and pushes a git tag
+   - Builds the gem
+   - Creates a GitHub Release with auto-generated notes and the gem attached
+   - Publishes the gem to GitHub Packages
+   - Publishes the gem to RubyGems.org (requires the `release` environment)
+   - Verifies the gem is available on RubyGems.org
+
+## RPM/DEB packaging
+
+After the gem is published to RubyGems, both RPM and DEB packages need to be updated in [theforeman/foreman-packaging](https://github.com/theforeman/foreman-packaging).
+
+A bot automatically creates PRs against the `rpm/develop` and `deb/develop` branches to pick up the new gem version. These PRs build packages for Foreman nightly.
+
+For stable Foreman releases (currently 3.17 and 3.18), cherry-pick the packaging commits from the develop branches into the corresponding stable branches. For each stable version you want to support:
+
+```bash
+cd foreman-packaging
+
+# RPM: cherry-pick from rpm/develop into a branch off the stable target
+git checkout rpm/3.18
+git checkout -b cherry-pick/rubygem-foreman_openbolt-rpm-3.18
+git cherry-pick <commit-from-rpm/develop>
+# Push to your fork and open a PR targeting rpm/3.18
+
+# DEB: same approach for the deb side
+git checkout deb/3.18
+git checkout -b cherry-pick/rubygem-foreman-openbolt-deb-3.18
+git cherry-pick <commit-from-deb/develop>
+# Push to your fork and open a PR targeting deb/3.18
+```
+
+PRs against stable branches should be labeled "Stable branch".
+
+**Alternative: manual version bump**
+
+If the cherry-pick doesn't apply cleanly, you can bump the version manually on the stable branch instead.
+
+*RPM:* Checkout the target branch and run `bump_rpm.sh`:
+```bash
+cd foreman-packaging
+git checkout rpm/3.18
+git checkout -b bump_rpm/rubygem-foreman_openbolt
+./bump_rpm.sh packages/plugins/rubygem-foreman_openbolt
+# Review changes, push to your fork, and open a PR targeting rpm/3.18
+```
+
+*DEB:* Checkout the target branch and update these files:
+- `debian/gem.list` -- new gem filename
+- `foreman_openbolt.rb` -- new version
+- `debian/control` -- dependency versions (if changed)
+- `debian/changelog` -- add a new entry
+
+```bash
+git checkout deb/3.18
+git checkout -b bump_deb/ruby-foreman-openbolt
+# Make the changes above, push to your fork, and open a PR targeting deb/3.18
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,47 @@
+# Usage
+
+(all screenshots were taken on Foreman 3.17)
+
+After installation, you will see a new UI element
+
+![foreman UI menu screenshot](../ext/foreman-ui-menu.png)
+
+The "Launch Task" option allows you to select any smartproxy with the `openbolt` feature (which is available when the OpenBolt Smartproxy plugin is installed).
+Afterwards you can select N targets to run the task and select an available task from the selected Smartproxy.
+On the right side you can configure OpenBolt connection settings.
+
+![launch task detail view](../ext/foreman-launch-task.png)
+
+After selecting a task, the task metadata is fetched and shown.
+Additional input elements will appear, if the task support it.
+
+![service task metadata](../ext/task-metadata-minimal.png)
+
+The metadata can contains a description and datatypes for tasks.
+Those information can be shown as well.
+
+![service task detailed metadata](../ext/task-metadata.png)
+
+While the task is running, the UI polls the status from the smart proxy.
+
+![task loading screen](../ext/task-running.png)
+
+After the task finished, it will display a success for failure page.
+
+![failed task view](../ext/task-execution-details.png)
+
+You can also see the used parameters for a task.
+
+![task used parameters](../ext/task-task-details.png)
+
+We also display the used OpenBolt command line, in case you want to manually run it or debug it.
+
+![display used OpenBolt command](../ext/task-log-output.png)
+
+OpenBolt returns JSON for executed tasks.
+That's visible in the UI.
+For failed tasks but also for passed tasks.
+
+![failed task output](../ext/task-result.png)
+
+![service task passed on two nodes](../ext/task-successful-result.png)

--- a/lib/foreman_openbolt/engine.rb
+++ b/lib/foreman_openbolt/engine.rb
@@ -35,6 +35,7 @@ module ForemanOpenbolt
               TRANSPORTS = {
                 ssh: N_('SSH'),
                 winrm: N_('WinRM'),
+                choria: N_('Choria'),
               }.freeze
               LOG_LEVELS = {
                 error: N_('Error'),
@@ -43,20 +44,48 @@ module ForemanOpenbolt
                 debug: N_('Debug'),
                 trace: N_('Trace'),
               }.freeze
+              CHORIA_TASK_AGENTS = {
+                bolt_tasks: N_('Bolt Tasks'),
+                shell: N_('Shell'),
+              }.freeze
               # rubocop:enable Lint/ConstantDefinitionInBlock
 
-              setting 'openbolt_transport',
-                type: :string,
-                default: 'ssh',
-                full_name: N_('Transport'),
-                description: N_('The transport method to use for connecting to target hosts'),
-                collection: proc { TRANSPORTS }
+              # General (all transports)
               setting 'openbolt_log-level',
                 type: :string,
                 default: 'debug',
                 full_name: N_('Log Level'),
                 description: N_('Set the log level during OpenBolt execution'),
                 collection: proc { LOG_LEVELS }
+              setting 'openbolt_noop',
+                type: :boolean,
+                default: false,
+                full_name: N_('No Operation'),
+                description: N_(
+                  'Run the OpenBolt command with the --noop flag, which will make no changes to the target host'
+                )
+              setting 'openbolt_password',
+                type: :string,
+                default: nil,
+                full_name: N_('Password'),
+                description: N_('Password used for SSH or WinRM authentication'),
+                encrypted: true
+              setting 'openbolt_tmpdir',
+                type: :string,
+                default: nil,
+                full_name: N_('Temporary Directory'),
+                description: N_('Directory to use for temporary files on target hosts during OpenBolt execution')
+              setting 'openbolt_transport',
+                type: :string,
+                default: 'ssh',
+                full_name: N_('Transport'),
+                description: N_('The transport method to use for connecting to target hosts'),
+                collection: proc { TRANSPORTS }
+              setting 'openbolt_user',
+                type: :string,
+                default: nil,
+                full_name: N_('User'),
+                description: N_('Username used for SSH or WinRM authentication')
               setting 'openbolt_verbose',
                 type: :boolean,
                 default: false,
@@ -65,29 +94,102 @@ module ForemanOpenbolt
                   'Run the OpenBolt command with the --verbose flag. This prints additional information ' \
                   'during OpenBolt execution and will print any out::verbose plan statements.'
                 )
-              setting 'openbolt_noop',
-                type: :boolean,
-                default: false,
-                full_name: N_('No Operation'),
+
+              # Choria
+              setting 'openbolt_choria-broker-timeout',
+                type: :integer,
+                default: nil,
+                full_name: N_('Choria Broker Timeout'),
+                description: N_('Time in seconds to wait when establishing a connection to a Choria broker.')
+              setting 'openbolt_choria-brokers',
+                type: :string,
+                default: nil,
+                full_name: N_('Choria Brokers'),
                 description: N_(
-                  'Run the OpenBolt command with the --noop flag, which will make no changes to the target host'
+                  'Comma-separated list of Choria broker addresses in host or host:port format ' \
+                  '(e.g. broker1.example.com:4222,broker2.example.com:4222). Port defaults to 4222 if omitted. ' \
+                  'When not set, the Choria client checks the config file, then SRV records, then falls back to puppet:4222.'
                 )
-              setting 'openbolt_tmpdir',
+              setting 'openbolt_choria-collective',
                 type: :string,
-                default: '',
-                full_name: N_('Temporary Directory'),
-                description: N_('Directory to use for temporary files on target hosts during OpenBolt execution')
-              setting 'openbolt_user',
+                default: nil,
+                full_name: N_('Choria Collective'),
+                description: N_('Choria collective to route messages through.')
+              setting 'openbolt_choria-command-timeout',
+                type: :integer,
+                default: nil,
+                full_name: N_('Choria Command Timeout'),
+                description: N_('Time in seconds to wait for command completion on target nodes.')
+              setting 'openbolt_choria-config-file',
                 type: :string,
-                default: '',
-                full_name: N_('User'),
-                description: N_('Username used for SSH or WinRM authentication')
-              setting 'openbolt_password',
+                default: nil,
+                full_name: N_('Choria Config File'),
+                description: N_(
+                  'Path on the smart proxy host to the Choria client configuration file. This file ' \
+                  'must be readable by the foreman-proxy user. When not set, the proxy uses a built-in default.'
+                )
+              setting 'openbolt_choria-mcollective-certname',
                 type: :string,
-                default: '',
-                full_name: N_('Password'),
-                description: N_('Password used for SSH or WinRM authentication'),
-                encrypted: true
+                default: nil,
+                full_name: N_('Choria MCollective Certname'),
+                description: N_(
+                  'Override the MCollective certname for Choria client identity. When not set, the ' \
+                  'proxy derives this automatically from its SSL certificate.'
+                )
+              setting 'openbolt_choria-puppet-environment',
+                type: :string,
+                default: nil,
+                full_name: N_('Choria Puppet Environment'),
+                description: N_(
+                  'Puppet environment used by the Choria bolt_tasks agent to locate task files. ' \
+                  "Only applies when the Choria Task Agent is 'bolt_tasks'. Defaults to " \
+                  "'production' when not specified."
+                )
+              setting 'openbolt_choria-rpc-timeout',
+                type: :integer,
+                default: nil,
+                full_name: N_('Choria RPC Timeout'),
+                description: N_('Time in seconds to wait for RPC responses from target nodes.')
+              setting 'openbolt_choria-ssl-ca',
+                type: :string,
+                default: nil,
+                full_name: N_('Choria SSL CA'),
+                description: N_(
+                  'Path on the smart proxy host to the Choria CA certificate. This file must be ' \
+                  'readable by the foreman-proxy user.'
+                )
+              setting 'openbolt_choria-ssl-cert',
+                type: :string,
+                default: nil,
+                full_name: N_('Choria SSL Certificate'),
+                description: N_(
+                  'Path on the smart proxy host to the Choria client SSL certificate. This file ' \
+                  'must be readable by the foreman-proxy user.'
+                )
+              setting 'openbolt_choria-ssl-key',
+                type: :string,
+                default: nil,
+                full_name: N_('Choria SSL Key'),
+                description: N_(
+                  'Path on the smart proxy host to the Choria client SSL private key. This file ' \
+                  'must be readable by the foreman-proxy user.'
+                )
+              setting 'openbolt_choria-task-agent',
+                type: :string,
+                default: 'bolt_tasks',
+                full_name: N_('Choria Task Agent'),
+                description: N_(
+                  'Choria agent used to execute tasks on target nodes. Use the bolt_tasks agent for ' \
+                  'standard OpenBolt tasks, or the shell agent to run shell commands.'
+                ),
+                collection: proc { CHORIA_TASK_AGENTS }
+              setting 'openbolt_choria-task-timeout',
+                type: :integer,
+                default: nil,
+                full_name: N_('Choria Task Timeout'),
+                description: N_('Time in seconds to wait for task completion on target nodes.')
+
+              # SSH
               setting 'openbolt_host-key-check',
                 type: :boolean,
                 default: true,
@@ -95,7 +197,7 @@ module ForemanOpenbolt
                 description: N_('Whether to perform host key verification when connecting to targets over SSH')
               setting 'openbolt_private-key',
                 type: :string,
-                default: '',
+                default: nil,
                 full_name: N_('SSH Private Key'),
                 description: N_(
                   'Path on the smart proxy host to the private key used for SSH authentication. This key must be ' \
@@ -103,7 +205,7 @@ module ForemanOpenbolt
                 )
               setting 'openbolt_run-as',
                 type: :string,
-                default: '',
+                default: nil,
                 full_name: N_('SSH Run As User'),
                 description: N_(
                   'The user to run commands as on the target host. This requires that the user specified ' \
@@ -111,10 +213,12 @@ module ForemanOpenbolt
                 )
               setting 'openbolt_sudo-password',
                 type: :string,
-                default: '',
+                default: nil,
                 full_name: N_('SSH Sudo Password'),
                 description: N_('Password used for privilege escalation when using SSH'),
                 encrypted: true
+
+              # WinRM
               setting 'openbolt_ssl',
                 type: :boolean,
                 default: true,

--- a/lib/proxy_api/openbolt.rb
+++ b/lib/proxy_api/openbolt.rb
@@ -52,15 +52,25 @@ module ProxyAPI
     end
 
     def parse_response(response, operation)
-      raise ProxyException.new(@url, nil, "No response from Smart Proxy during #{operation}") unless response
+      unless response
+        raise ProxyException.new(
+          @url, RuntimeError.new("No response from Smart Proxy during #{operation}"),
+          "No response from Smart Proxy during #{operation}"
+        )
+      end
 
       body = response.body
-      raise ProxyException.new(@url, nil, "Empty response body from Smart Proxy during #{operation}") if body.nil?
+      if body.nil?
+        raise ProxyException.new(
+          @url, RuntimeError.new("Empty response body from Smart Proxy during #{operation}"),
+          "Empty response body from Smart Proxy during #{operation}"
+        )
+      end
 
       JSON.parse(body)
     rescue JSON::ParserError => e
       raise ProxyException.new(
-        @url, nil,
+        @url, e,
         "Invalid JSON from Smart Proxy during #{operation}: #{e.message}. " \
         "Response body (first 500 chars): #{body.to_s[0..500]}"
       )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foreman_openbolt",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foreman_openbolt",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "dependencies": {
         "react-intl": "^2.8.0"
       },

--- a/test/acceptance/tests/transport_options_test.rb
+++ b/test/acceptance/tests/transport_options_test.rb
@@ -91,13 +91,13 @@ class TransportOptionsTest < AcceptanceTestCase
       text: 'Select a task to see parameters', wait: 10
   end
 
-  def test_transport_option_renders_as_select_with_ssh_and_winrm
-    # The transport OpenBolt option has type ["ssh", "winrm"] and
-    # ParameterField renders array-typed values as a <select>.
+  def test_transport_option_renders_as_select_with_ssh_winrm_and_choria
+    # The transport OpenBolt option has type ["ssh", "winrm", "choria"]
+    # and ParameterField renders array-typed values as a <select>.
     field = find_by_id('param_transport', wait: 10)
     assert_equal 'select', field.tag_name
     option_values = all('#param_transport option').map(&:value)
-    assert_equal %w[ssh winrm], option_values
+    assert_equal %w[ssh winrm choria], option_values
     assert_equal 'ssh', field.value
   end
 
@@ -117,5 +117,45 @@ class TransportOptionsTest < AcceptanceTestCase
     select 'ssh', from: 'param_transport'
     assert_selector '#param_host-key-check', wait: 10
     assert_selector '#param_private-key', wait: 10
+  end
+
+  def test_switching_transport_to_choria_hides_ssh_only_options_and_shows_choria_options
+    # SSH-only options are present on load because the default transport is ssh.
+    assert_selector '#param_host-key-check', wait: 10
+    assert_selector '#param_private-key', wait: 10
+    assert_selector '#param_run-as', wait: 10
+    assert_selector '#param_sudo-password', wait: 10
+
+    # Switching transport to choria should hide ssh-only options and reveal
+    # choria-tagged options (OpenBoltOptionsSection filters by transport).
+    select 'choria', from: 'param_transport'
+    assert_no_selector '#param_host-key-check', wait: 10
+    assert_no_selector '#param_private-key', wait: 10
+    assert_no_selector '#param_run-as', wait: 10
+    assert_no_selector '#param_sudo-password', wait: 10
+
+    assert_selector '#param_choria-config-file', wait: 10
+    assert_selector '#param_choria-ssl-ca', wait: 10
+    assert_selector '#param_choria-brokers', wait: 10
+
+    # choria-task-agent must render as a <select> whose options match the
+    # proxy's enum exactly. The launch form gets the enum from the proxy's
+    # option metadata type array, so a drift in the proxy-side enum (or a
+    # mismatch with engine.rb's CHORIA_TASK_AGENTS collection shown on the
+    # Settings page) would only surface at task launch time otherwise.
+    task_agent = find_by_id('param_choria-task-agent', wait: 10)
+    assert_equal 'select', task_agent.tag_name
+    assert_equal %w[bolt_tasks shell], all('#param_choria-task-agent option').map(&:value)
+    assert_equal 'bolt_tasks', task_agent.value
+
+    # Switching back to ssh restores ssh-only options and hides choria-only ones.
+    # Includes the select-type field so a future regression that special-cases
+    # selects in the transport filter would be caught here.
+    select 'ssh', from: 'param_transport'
+    assert_selector '#param_host-key-check', wait: 10
+    assert_selector '#param_private-key', wait: 10
+    assert_no_selector '#param_choria-config-file', wait: 10
+    assert_no_selector '#param_choria-task-agent', wait: 10
+    assert_no_selector '#param_choria-brokers', wait: 10
   end
 end

--- a/test/unit/controllers/task_controller_test.rb
+++ b/test/unit/controllers/task_controller_test.rb
@@ -141,6 +141,20 @@ class TaskControllerTest < ActionController::TestCase
       assert_match(/Task execution failed/, JSON.parse(response.body)['error'])
     end
 
+    test 'returns bad_gateway when proxy returns invalid JSON' do
+      stub_request(:post, "#{@proxy.url}/openbolt/launch/task")
+        .to_return(status: 200, body: 'not valid json',
+          headers: { 'Content-Type' => 'application/json' })
+
+      post :launch_task, params: {
+        proxy_id: @proxy.id,
+        task_name: 'mymod::install',
+        targets: 'host1',
+      }, session: @session
+      assert_response :bad_gateway
+      assert_match(/Smart Proxy error/, JSON.parse(response.body)['error'])
+    end
+
     test 'returns error when proxy returns no job ID' do
       stub_request(:post, "#{@proxy.url}/openbolt/launch/task")
         .to_return(status: 200, body: { 'status' => 'ok' }.to_json,
@@ -214,7 +228,7 @@ class TaskControllerTest < ActionController::TestCase
       ForemanTasks.stubs(:async_task)
     end
 
-    test 'replaces encrypted placeholder with real setting value before sending to proxy' do
+    test 'sends real encrypted value to proxy and scrubs it in database' do
       Setting['openbolt_password'] = 'real-secret-password'
 
       post :launch_task, params: {
@@ -226,27 +240,11 @@ class TaskControllerTest < ActionController::TestCase
 
       assert_response :success
 
-      # Verify the real value was sent to the proxy (not the placeholder)
-      proxy_request = WebMock::RequestRegistry.instance
-                                              .requested_signatures
-                                              .hash
-                                              .keys
-                                              .find { |sig| sig.uri.path == '/openbolt/launch/task' }
-      sent_body = JSON.parse(proxy_request.body)
-      assert_equal 'real-secret-password', sent_body['options']['password']
-    end
+      assert_requested(:post, "#{@proxy.url}/openbolt/launch/task") do |req|
+        sent_body = JSON.parse(req.body)
+        sent_body['options']['password'] == 'real-secret-password'
+      end
 
-    test 'scrubs encrypted options before storing in database' do
-      Setting['openbolt_password'] = 'real-secret-password'
-
-      post :launch_task, params: {
-        proxy_id: @proxy.id,
-        task_name: 'mymod::install',
-        targets: 'host1.example.com',
-        options: { 'password' => '[Use saved encrypted default]', 'transport' => 'ssh' },
-      }, session: @session
-
-      assert_response :success
       job = ForemanOpenbolt::TaskJob.find_by(job_id: 'encrypted-job-1')
       assert_equal '*****', job.openbolt_options['password']
       assert_equal 'ssh', job.openbolt_options['transport']
@@ -315,6 +313,83 @@ class TaskControllerTest < ActionController::TestCase
 
       body = JSON.parse(response.body)
       assert_equal '[Use saved encrypted default]', body['password']['default']
+    end
+  end
+
+  context 'fetch_openbolt_options with Choria settings defaults' do
+    # Mirrors the real GET /openbolt/tasks/options response for Choria
+    # (see smart_proxy_openbolt/lib/smart_proxy_openbolt/main.rb OPENBOLT_OPTIONS).
+    def self.choria_proxy_options
+      {
+        'choria-task-agent' => { 'type' => %w[bolt_tasks shell], 'transport' => ['choria'], 'sensitive' => false },
+        'choria-config-file' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-mcollective-certname' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-ssl-ca' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-ssl-cert' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-ssl-key' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-collective' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-puppet-environment' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-rpc-timeout' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-task-timeout' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-command-timeout' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-brokers' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+        'choria-broker-timeout' => { 'type' => 'string', 'transport' => ['choria'], 'sensitive' => false },
+      }
+    end
+
+    test 'merges all Choria setting values into their option defaults' do
+      Setting['openbolt_choria-task-agent'] = 'shell'
+      Setting['openbolt_choria-config-file'] = '/etc/choria/client.conf'
+      Setting['openbolt_choria-mcollective-certname'] = 'primary.example.com'
+      Setting['openbolt_choria-ssl-ca'] = '/etc/choria/ca.pem'
+      Setting['openbolt_choria-ssl-cert'] = '/etc/choria/client.pem'
+      Setting['openbolt_choria-ssl-key'] = '/etc/choria/client.key'
+      Setting['openbolt_choria-collective'] = 'mcollective'
+      Setting['openbolt_choria-puppet-environment'] = 'production'
+      Setting['openbolt_choria-rpc-timeout'] = 60
+      Setting['openbolt_choria-task-timeout'] = 300
+      Setting['openbolt_choria-command-timeout'] = 120
+      Setting['openbolt_choria-brokers'] = 'broker.example.com:4222'
+      Setting['openbolt_choria-broker-timeout'] = 10
+
+      stub_request(:get, "#{@proxy.url}/openbolt/tasks/options")
+        .to_return(status: 200, body: self.class.choria_proxy_options.to_json,
+          headers: { 'Content-Type' => 'application/json' })
+
+      get :fetch_openbolt_options, params: { proxy_id: @proxy.id }, session: @session
+      assert_response :success
+
+      body = JSON.parse(response.body)
+      assert_equal 'shell', body['choria-task-agent']['default']
+      assert_equal '/etc/choria/client.conf', body['choria-config-file']['default']
+      assert_equal 'primary.example.com', body['choria-mcollective-certname']['default']
+      assert_equal '/etc/choria/ca.pem', body['choria-ssl-ca']['default']
+      assert_equal '/etc/choria/client.pem', body['choria-ssl-cert']['default']
+      assert_equal '/etc/choria/client.key', body['choria-ssl-key']['default']
+      assert_equal 'mcollective', body['choria-collective']['default']
+      assert_equal 'production', body['choria-puppet-environment']['default']
+      assert_equal 60, body['choria-rpc-timeout']['default']
+      assert_equal 300, body['choria-task-timeout']['default']
+      assert_equal 120, body['choria-command-timeout']['default']
+      assert_equal 'broker.example.com:4222', body['choria-brokers']['default']
+      assert_equal 10, body['choria-broker-timeout']['default']
+    end
+
+    test 'omits nil-default settings and keeps real defaults when Choria settings are not configured' do
+      stub_request(:get, "#{@proxy.url}/openbolt/tasks/options")
+        .to_return(status: 200, body: self.class.choria_proxy_options.to_json,
+          headers: { 'Content-Type' => 'application/json' })
+
+      get :fetch_openbolt_options, params: { proxy_id: @proxy.id }, session: @session
+      assert_response :success
+
+      body = JSON.parse(response.body)
+      assert_equal 'bolt_tasks', body['choria-task-agent']['default']
+      assert_not body['choria-config-file'].key?('default')
+      assert_not body['choria-mcollective-certname'].key?('default')
+      assert_not body['choria-ssl-key'].key?('default')
+      assert_not body['choria-brokers'].key?('default')
+      assert_not body['choria-broker-timeout'].key?('default')
     end
   end
 

--- a/webpack/src/Components/LaunchTask/__tests__/ParameterField.test.js
+++ b/webpack/src/Components/LaunchTask/__tests__/ParameterField.test.js
@@ -83,4 +83,49 @@ describe('ParameterField', () => {
     fireEvent.change(input, { target: { value: 'new-value' } });
     expect(handleChange).toHaveBeenCalledWith('username', 'new-value');
   });
+
+  test('shows empty field for encrypted default instead of the placeholder value', () => {
+    const { container } = render(
+      <ParameterField
+        name="password"
+        metadata={{
+          type: 'String',
+          sensitive: true,
+          default: '[Use saved encrypted default]',
+        }}
+        onChange={jest.fn()}
+      />
+    );
+    const input = container.querySelector('input[type="password"]');
+    expect(input.value).toBe('');
+  });
+
+  test('shows encrypted placeholder when value matches placeholder', () => {
+    const { container } = render(
+      <ParameterField
+        name="password"
+        metadata={{
+          type: 'String',
+          sensitive: true,
+          default: '[Use saved encrypted default]',
+        }}
+        value="[Use saved encrypted default]"
+        onChange={jest.fn()}
+      />
+    );
+    const input = container.querySelector('input[type="password"]');
+    expect(input.value).toBe('[Use saved encrypted default]');
+  });
+
+  test('renders empty text input when value is undefined and no default', () => {
+    const { container } = render(
+      <ParameterField
+        name="tmpdir"
+        metadata={{ type: 'String' }}
+        onChange={jest.fn()}
+      />
+    );
+    const input = container.querySelector('input[type="text"]');
+    expect(input.value).toBe('');
+  });
 });

--- a/webpack/src/Components/LaunchTask/hooks/__tests__/useOpenBoltOptions.test.js
+++ b/webpack/src/Components/LaunchTask/hooks/__tests__/useOpenBoltOptions.test.js
@@ -47,6 +47,7 @@ describe('useOpenBoltOptions', () => {
       transport: 'ssh',
       verbose: false,
     });
+    expect(result.current.openBoltOptions.verbose).toBe(false);
     expect(result.current.openBoltOptions.user).toBeUndefined();
   });
 

--- a/webpack/src/Components/TaskExecution/__tests__/LoadingIndicator.test.js
+++ b/webpack/src/Components/TaskExecution/__tests__/LoadingIndicator.test.js
@@ -8,7 +8,7 @@ describe('LoadingIndicator', () => {
     expect(screen.getByText(/running/i)).toBeInTheDocument();
   });
 
-  test('shows running status message for pending jobs', () => {
+  test('shows current status message for pending jobs', () => {
     render(<LoadingIndicator jobStatus="pending" />);
     expect(screen.getByText(/pending/i)).toBeInTheDocument();
   });

--- a/webpack/src/Components/TaskExecution/hooks/__tests__/useJobPolling.test.js
+++ b/webpack/src/Components/TaskExecution/hooks/__tests__/useJobPolling.test.js
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe('useJobPolling', () => {
-  test('returns undefined state when jobId is null', () => {
+  test('returns initial pending state and does not poll when jobId is null', () => {
     const { result } = renderHook(() => useJobPolling(null));
     expect(result.current.status).toBe('pending');
     expect(result.current.isPolling).toBe(false);


### PR DESCRIPTION
- Add Choria transport support with 13 new Foreman Settings for Choria options
- Split the README.md and put most of it in the docs directory with links in the readme, since it was getting long
- Rearranged Foreman OpenBolt settings to make it easier to find the one you're looking for
- Use nil defaults for settings that previously were using an empty string to prevent sending unnecessary options to the proxy
- Fix proxy exception handling in launch_task to return 502 instead of 500