### PR TITLE
Add backport rake command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,4 +20,36 @@ end
 DEFAULT_FOREMAN_VERSION = latest_foreman_version
 FOREMAN_VERSION = ENV.fetch('FOREMAN_VERSION', DEFAULT_FOREMAN_VERSION)
 
+def minimum_supported_foreman_version
+  engine_path = File.join(__dir__, 'lib', 'foreman_openbolt', 'engine.rb')
+  content = File.read(engine_path)
+  match = content.match(/requires_foreman\s+['"]>= (\d+\.\d+)/)
+  abort 'Could not parse minimum Foreman version from engine.rb'.red unless match
+  match[1]
+end
+
+def supported_foreman_releases
+  min = Gem::Version.new(minimum_supported_foreman_version)
+  max = Gem::Version.new(DEFAULT_FOREMAN_VERSION)
+
+  result = Shell.capture(
+    ['git', 'ls-remote', '--tags', 'https://github.com/theforeman/foreman.git'],
+    print_command: false, allowed_exit_codes: [0, 1]
+  )
+  tags = result.output.scan(%r{refs/tags/([^\s]+)$}).flatten
+  versions = tags.filter_map do |tag|
+    Gem::Version.new(tag)
+  rescue ArgumentError
+    nil
+  end
+
+  versions.reject(&:prerelease?)
+          .map { |v| "#{v.segments[0]}.#{v.segments[1]}" }
+          .uniq
+          .map { |v| Gem::Version.new(v) }
+          .grep(min..max)
+          .sort
+          .map(&:to_s)
+end
+
 task default: :lint

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,23 +33,22 @@ After the gem is published to RubyGems, both RPM and DEB packages need to be upd
 
 A bot automatically creates PRs against the `rpm/develop` and `deb/develop` branches to pick up the new gem version. These PRs build packages for Foreman nightly.
 
-For stable Foreman releases (currently 3.17 and 3.18), cherry-pick the packaging commits from the develop branches into the corresponding stable branches. For each stable version you want to support:
+For stable Foreman releases, cherry-pick the packaging commits from the develop branches into the corresponding stable branches. The `backport` rake task automates this for all supported versions:
 
 ```bash
-cd foreman-packaging
-
-# RPM: cherry-pick from rpm/develop into a branch off the stable target
-git checkout rpm/3.18
-git checkout -b cherry-pick/rubygem-foreman_openbolt-rpm-3.18
-git cherry-pick <commit-from-rpm/develop>
-# Push to your fork and open a PR targeting rpm/3.18
-
-# DEB: same approach for the deb side
-git checkout deb/3.18
-git checkout -b cherry-pick/rubygem-foreman-openbolt-deb-3.18
-git cherry-pick <commit-from-deb/develop>
-# Push to your fork and open a PR targeting deb/3.18
+rake backport
 ```
+
+This will:
+1. Determine the supported Foreman version range (from `engine.rb` and the latest Foreman release tag)
+2. Clone `foreman-packaging` with your fork as `origin` (detected via `gh auth`)
+3. Find the latest `smart_proxy_openbolt` and `foreman_openbolt` bump commits on `rpm/develop` and `deb/develop`
+4. For each supported version, create a cherry-pick branch, apply both commits, and push to your fork
+5. If `gh` is available and authenticated, create PRs against `theforeman/foreman-packaging`
+
+The task requires `gh` to be authenticated with a classic token that has the `public_repo` scope, or a fine-grained token with `read:org` access to `theforeman` and push access to your fork.
+
+You can override the GitHub username with `GITHUB_USER=<username> rake backport`.
 
 PRs against stable branches should be labeled "Stable branch".
 

--- a/rakelib/backport.rake
+++ b/rakelib/backport.rake
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require_relative 'utils/shell'
+
+FOREMAN_PACKAGING_UPSTREAM_URL = 'https://github.com/theforeman/foreman-packaging'
+
+def backport_github_username
+  return ENV['GITHUB_USER'] if ENV['GITHUB_USER']
+
+  result = Shell.capture(
+    ['gh', 'api', 'user', '--jq', '.login'],
+    print_command: false, allowed_exit_codes: [0, 1]
+  )
+  login = result.output.strip
+  return login if result.exitcode.zero? && !login.empty?
+
+  abort 'Could not determine GitHub username. Set GITHUB_USER env var or authenticate the gh CLI.'.red
+end
+
+def clone_foreman_packaging
+  dir = File.join(Dir.tmpdir, 'foreman-packaging-backport')
+  gh_user = backport_github_username
+  origin_url = "git@github.com:#{gh_user}/foreman-packaging"
+
+  if File.directory?(dir)
+    puts 'Updating existing foreman-packaging clone...'.magenta
+    Shell.run(['git', '-C', dir, 'remote', 'set-url', 'origin', origin_url])
+    Shell.run(['git', '-C', dir, 'fetch', 'upstream'])
+  else
+    puts 'Cloning foreman-packaging...'.magenta
+    Shell.run(['git', 'clone', FOREMAN_PACKAGING_UPSTREAM_URL, dir])
+    Shell.run(['git', '-C', dir, 'remote', 'rename', 'origin', 'upstream'])
+    Shell.run(['git', '-C', dir, 'remote', 'add', 'origin', origin_url])
+  end
+
+  dir
+end
+
+def find_bump_commit(dir, branch, package_name)
+  result = Shell.capture(
+    ['git', '-C', dir, 'log', branch, '-1', '--format=%H %s', '--grep', package_name],
+    print_command: false
+  )
+  line = result.output.strip
+  abort "No commit found for '#{package_name}' on #{branch}".red if line.empty?
+
+  sha, message = line.split(' ', 2)
+  version_match = message.match(/to (\d+\.\d+\.\d+)/)
+  gem_version = version_match ? version_match[1] : 'unknown'
+
+  { sha: sha, message: message, version: gem_version }
+end
+
+def gh_available?
+  Shell.capture(['which', 'gh'], print_command: false, allowed_exit_codes: [0, 1]).exitcode.zero?
+end
+
+def verify_gh_permissions
+  return unless gh_available?
+
+  puts 'Checking gh authentication and permissions...'.magenta
+
+  gh_user = backport_github_username
+  puts "  GitHub user: #{gh_user}".green
+
+  result = Shell.capture(
+    ['gh', 'api', "repos/#{gh_user}/foreman-packaging", '--jq', '.fork'],
+    print_command: false, allowed_exit_codes: [0, 1]
+  )
+  if result.exitcode.zero? && result.output.strip == 'true'
+    puts "  Fork #{gh_user}/foreman-packaging exists".green
+  else
+    abort "Fork #{gh_user}/foreman-packaging not found. Fork theforeman/foreman-packaging first.".red
+  end
+
+  result = Shell.capture(
+    ['gh', 'api', "repos/#{gh_user}/foreman-packaging", '--jq', '.permissions.push'],
+    print_command: false, allowed_exit_codes: [0, 1]
+  )
+  unless result.exitcode.zero? && result.output.strip == 'true'
+    abort "gh token does not have push access to #{gh_user}/foreman-packaging.".red
+  end
+  puts '  Push access to fork confirmed'.green
+
+  result = Shell.capture(
+    ['gh', 'api', "orgs/theforeman/memberships/#{gh_user}", '--jq', '.state'],
+    print_command: false, allowed_exit_codes: [0, 1]
+  )
+  unless result.exitcode.zero? && result.output.strip == 'active'
+    abort "gh token cannot read org membership for theforeman. Ensure the token has 'read:org' permission.".red
+  end
+  puts '  Org membership access confirmed'.green
+
+  result = Shell.capture(
+    ['gh', 'api', 'repos/theforeman/foreman-packaging', '--jq', '.permissions.push'],
+    print_command: false, allowed_exit_codes: [0, 1]
+  )
+  if result.exitcode.zero? && result.output.strip == 'true'
+    puts '  PR creation access confirmed'.green
+  else
+    abort 'gh token lacks push access to theforeman/foreman-packaging, which is required to create PRs.'.red
+  end
+end
+
+def backport_to_branches(dir, branch_prefix:, timestamp:, pr_urls:)
+  develop_ref = "upstream/#{branch_prefix}/develop"
+
+  smart_proxy_pkg, foreman_pkg = if branch_prefix == 'rpm'
+                                   ['rubygem-smart_proxy_openbolt', 'rubygem-foreman_openbolt']
+                                 else
+                                   ['ruby-smart-proxy-openbolt', 'ruby-foreman-openbolt']
+                                 end
+
+  puts "\nLooking for package bump commits on #{develop_ref}...".magenta
+
+  smart_proxy_commit = find_bump_commit(dir, develop_ref, smart_proxy_pkg)
+  puts "  #{smart_proxy_pkg}: #{smart_proxy_commit[:sha][0..7]} (#{smart_proxy_commit[:version]})".green
+
+  foreman_commit = find_bump_commit(dir, develop_ref, foreman_pkg)
+  puts "  #{foreman_pkg}: #{foreman_commit[:sha][0..7]} (#{foreman_commit[:version]})".green
+
+  versions = supported_foreman_releases
+  use_gh = gh_available?
+  gh_user = use_gh ? backport_github_username : nil
+
+  versions.each do |version|
+    target_ref = "upstream/#{branch_prefix}/#{version}"
+    branch_name = "cherry-pick/openbolt_#{branch_prefix}-#{version}_#{timestamp}"
+
+    puts "\nBackporting to #{branch_prefix}/#{version}...".magenta
+
+    Shell.run(['git', '-C', dir, 'checkout', '--force', target_ref], print_command: false)
+    Shell.run(['git', '-C', dir, 'clean', '-fd'], print_command: false)
+    Shell.run(['git', '-C', dir, 'checkout', '-b', branch_name])
+    Shell.run(['git', '-C', dir, 'cherry-pick', smart_proxy_commit[:sha]])
+    Shell.run(['git', '-C', dir, 'cherry-pick', foreman_commit[:sha]])
+    Shell.run(['git', '-C', dir, 'push', 'origin', branch_name])
+    puts "  Pushed #{branch_name}".green
+
+    next unless use_gh
+
+    pr_title = "Cherry pick smart_proxy_openbolt #{smart_proxy_commit[:version]} " \
+               "and foreman_openbolt #{foreman_commit[:version]} " \
+               "to #{branch_prefix}/#{version}"
+    result = Shell.capture(
+      ['gh', 'pr', 'create',
+       '--repo', 'theforeman/foreman-packaging',
+       '--base', "#{branch_prefix}/#{version}",
+       '--head', "#{gh_user}:#{branch_name}",
+       '--title', pr_title,
+       '--body', ''],
+      allowed_exit_codes: [0, 1]
+    )
+    if result.exitcode.zero?
+      pr_urls << result.output.strip
+      puts "  PR created for #{branch_prefix}/#{version}".green
+    else
+      puts "  PR creation failed for #{branch_prefix}/#{version}".yellow
+    end
+  end
+end
+
+desc 'Cherry-pick OpenBolt package bumps to all supported Foreman release branches in foreman-packaging'
+task :backport do
+  verify_gh_permissions
+  dir = clone_foreman_packaging
+  timestamp = Time.now.utc.strftime('%Y-%m-%d_%H-%M-%S')
+  versions = supported_foreman_releases
+
+  puts "Supported Foreman releases: #{versions.join(', ')}".magenta
+  puts "Backport timestamp: #{timestamp}".magenta
+
+  pr_urls = []
+  backport_to_branches(dir, branch_prefix: 'rpm', timestamp: timestamp, pr_urls: pr_urls)
+  backport_to_branches(dir, branch_prefix: 'deb', timestamp: timestamp, pr_urls: pr_urls)
+
+  puts "\nBackport complete!".green
+  unless pr_urls.empty?
+    puts "\nPull requests:".magenta
+    pr_urls.each { |url| puts "  #{url}" }
+  end
+end


### PR DESCRIPTION
Because cherry picking release commits from rpm/develop and deb/develop into every release branch on foreman-packaging, this rake task will do it for you. Requires using the gh app with a classic token with repo and read:org permissions.