### PR TITLE
Small fixes

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,8 @@ Acceptance tests exercise the plugin through the browser using Capybara and Sele
 **Prerequisites:**
 
 ```bash
-bundle install --with acceptance
+bundle config set --local with acceptance
+bundle install
 ```
 
 The [smart_proxy_openbolt](https://github.com/overlookinfra/smart_proxy_openbolt) and [foreman-packaging](https://github.com/theforeman/foreman-packaging) repos are cloned automatically when needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foreman_openbolt",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foreman_openbolt",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "react-intl": "^2.8.0"
       },

--- a/rakelib/acceptance.rake
+++ b/rakelib/acceptance.rake
@@ -395,6 +395,22 @@ namespace :acceptance do
     task.options = ENV.fetch('TESTOPTS', '--verbose')
     task.verbose = true
   end
+  task :run => :verify_acceptance_gems
+
+  task :verify_acceptance_gems do
+    require 'capybara'
+  rescue LoadError
+    abort <<~MSG.red
+      FATAL: cannot load 'capybara'. Acceptance test gems are not installed.
+
+      The :acceptance group is optional in the Gemfile. Install it with:
+
+          bundle config set --local with acceptance
+          bundle install
+
+      Then re-run this task.
+    MSG
+  end
 
   desc 'Stop acceptance test containers'
   task :down do

--- a/rakelib/acceptance.rake
+++ b/rakelib/acceptance.rake
@@ -395,8 +395,10 @@ namespace :acceptance do
     task.options = ENV.fetch('TESTOPTS', '--verbose')
     task.verbose = true
   end
+  desc 'Run the acceptance tests'
   task :run => :verify_acceptance_gems
 
+  desc 'Verify that the acceptance set of gems are installed before running tests'
   task :verify_acceptance_gems do
     require 'capybara'
   rescue LoadError

--- a/test/acceptance/acceptance_helper.rb
+++ b/test/acceptance/acceptance_helper.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# Suppress a noisy deprecation warning emitted by Capybara 3.40.0 on Ruby 3.4+:
+#   URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.
+# Fixed upstream in teamcapybara/capybara#2781 but not yet released. Remove this
+# block once Capybara ships a release with that PR.
+module SuppressCapybaraURIDeprecation
+  TARGET = 'URI::RFC3986_PARSER.make_regexp is obsolete'
+  def warn(message, **)
+    return if message.to_s.include?(TARGET)
+    super
+  end
+end
+Warning.singleton_class.prepend(SuppressCapybaraURIDeprecation)
+
 require 'capybara'
 require 'capybara/dsl'
 require 'selenium-webdriver'


### PR DESCRIPTION
Suppress warnings from Capybara until they cut a new release, check that the user has installed acceptance gems before running, update package-lock.json.