### PR TITLE
Relax foreman-tasks dependency upper bound to < 14

### DIFF
--- a/foreman_openbolt.gemspec
+++ b/foreman_openbolt.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0', '< 5'
 
-  s.add_dependency 'foreman-tasks', '>= 11.0.0', '< 13'
+  s.add_dependency 'foreman-tasks', '>= 11.0.0', '< 14'
 end


### PR DESCRIPTION
foreman-tasks 13.0.0 has been released. The current upper bound of `< 13` causes repoclosure failures for packages depending on this gem when built against repositories containing foreman-tasks 13.x.

This relaxes the constraint to `< 14` to restore compatibility.

See: https://github.com/theforeman/foreman-packaging/pull/13661